### PR TITLE
생성한 issue를 creator에게 auto-assign 합니다

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -1,0 +1,21 @@
+name: Auto Assign Issue to Creator
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+    issues: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Assign the issue to the creator
+      run: |
+        curl \
+          -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees \
+          -d '{"assignees": ["${{ github.actor }}"]}'


### PR DESCRIPTION
<img width="1317" alt="image" src="https://github.com/HYU-PS-STUDY/Baekjoon/assets/81248624/c814d771-2c3f-49ee-ae49-2208f97cba00">


`Assignee` 를 매번 할당하는게 번거로울 것 같아 제안드려봅니다.
피드백 부탁드립니다 :)